### PR TITLE
Compatibility with rstan 2.26

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     rstan (>= 2.21.2),
     rstantools (>= 2.1.1),
     stringr,
-    tidyr
+    tidyr,
+    RcppParallel (>= 5.0.1),
 Suggests:
   ggplot2,
   shinystan,
@@ -40,7 +41,8 @@ LinkingTo:
     rstan, 
     BH (>= 1.72),
     Rcpp,
-    RcppEigen
+    RcppEigen,
+    RcppParallel (>= 5.0.1)
 URL:
   https://github.com/dmenne/breathteststan
 BugReports: https://github.com/dmenne/breathteststan/issues

--- a/configure
+++ b/configure
@@ -1,0 +1,2 @@
+#! /bin/sh
+"${R_HOME}/bin/Rscript" -e "rstantools::rstan_config()"

--- a/configure.win
+++ b/configure.win
@@ -1,0 +1,2 @@
+#! /bin/sh
+"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "rstantools::rstan_config()"


### PR DESCRIPTION
Hi Dieter,

This PR adds the changes needed for your package to be compatible with the upcoming rstan 2.26. The additions allow the package to link against `RcppParallel`, and the addition of the configure files allows `rstantools` to update your Makevars prior to package installation.

Let me know if you have any questions/clarifications about the changes.

Thanks!
Andrew